### PR TITLE
Add onEndWithOptions

### DIFF
--- a/src/Touch.elm
+++ b/src/Touch.elm
@@ -260,6 +260,7 @@ onMove tagger =
 
 
 {-| Record the end of a touch gesture.
+This event has `preventDefault = True` to avoid double event with `onClick` after `onEnd`
 -}
 onEnd : (Event -> msg) -> Html.Attribute msg
 onEnd tagger =
@@ -271,7 +272,7 @@ onEnd tagger =
         decodeTouch "changedTouches" (Touch End >> tagger)
 
 
-{-| Record the end of a touch gesture.
+{-| Record the end of a touch gesture with options.
 -}
 onEndWithOptions : Html.Events.Options -> (Event -> msg) -> Html.Attribute msg
 onEndWithOptions options tagger =

--- a/src/Touch.elm
+++ b/src/Touch.elm
@@ -13,6 +13,7 @@ module Touch
         , isUpSwipe
         , locate
         , onEnd
+        , onEndWithOptions
         , onMove
         , onStart
         , record
@@ -66,7 +67,7 @@ In your update:
 
 # Events stuff
 
-@docs onMove, onEnd, onStart
+@docs onMove, onEnd, onStart, onEndWithOptions
 
 
 # Keep some state around
@@ -267,4 +268,12 @@ onEnd tagger =
         , preventDefault = True
         }
     <|
+        decodeTouch "changedTouches" (Touch End >> tagger)
+
+
+{-| Record the end of a touch gesture.
+-}
+onEndWithOptions : Html.Events.Options -> (Event -> msg) -> Html.Attribute msg
+onEndWithOptions options tagger =
+    onWithOptions "touchend" options <|
         decodeTouch "changedTouches" (Touch End >> tagger)


### PR DESCRIPTION
Add `onEndWithOptions` so that we can set `preventDefault` to `False` if needed (because child components need to listen to `onClick` events for instance.

For more information see this issue: #1 